### PR TITLE
Fix reading ignored/untracked files in Git

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -561,7 +561,7 @@ fi
 
 # Add untracked/ignored files to the ignore list
 if [ "$repository_type" = "git" ]; then
-	_vcs_ignore=$( git --git-dir="$topdir/.git" ls-files --others | sed -e ':a;N;s/\n/:/;ta' )
+	_vcs_ignore=$( git -C "$topdir" ls-files --others | sed -e ':a;N;s/\n/:/;ta' )
 	if [ -n "$_vcs_ignore" ]; then
 		if [ -z "$ignore" ]; then
 			ignore="$_vcs_ignore"


### PR DESCRIPTION
I admit I'm not very knowledgable about the internal workings of Git (or bash scripting, for that matter) but the command you were using was reading the files from the current working directory (the packager's repo) rather than the addon's directory ($topdir).

If it matters, I'm using this file structure:

```
AddOns
    Grid
        .git
        Grid.toc
        -- other files
     zzz-packager
        .git
        release.sh
```

And I'm running the packager from the ```zzz-packager``` directory with this command:

    ./release.sh -t ../Grid

Running your line in the terminal, I couldn't get any variation on paths -- relative or absolute, to `Grid` or `Grid/.git` -- to work with `--git-dir`. Everything I tried either listed the packager's ignored/untracked files instead, or just gave an error stating that the given path wasn't a git repository.

Based on [this StackOverflow post](https://stackoverflow.com/a/1386350) your way might work if you also added `--work-tree`, but `-C` works as expected already and is a lot shorter:

> **-C \<path\>**
> Run as if git was started in \<path\> instead of the current working directory.

(From <https://git-scm.com/docs/git>)