### PR TITLE
Convert manual changelog to BBCode for WoWInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ __release.sh__ reads __.pkgmeta__ and supports the following directives. See the
 You can also use a few directives for WoWInterface uploading.
 
   - *wowi-archive-previous* : `yes|no` (defaults to yes) Archive the previous release.
-  - *wowi-create-changelog* : `yes|no` (defaults to yes) Generate a Git changelog using BBCode that will be set when uploading. A manual changelog will always be used if set in the .pkgmeta.
+  - *wowi-create-changelog* : `yes|no` (defaults to yes) Generate a Git changelog using BBCode that will be set when uploading. A manual changelog will always be used if set in the .pkgmeta. If you have [cmark](https://github.com/jgm/cmark) installed, manual changelogs in Markdown format will be converted to BBCode; otherwise, the manual changelog will be used as-is.
 
 __release.sh__ supports the following repository substitution keywords when
 copying the files from the checkout into the project directory. See the [CurseForge Knowledge base page](http://legacy.curseforge.com/wiki/repositories/repository-keyword-substitutions/) for more info.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ __release.sh__ reads __.pkgmeta__ and supports the following directives. See the
 You can also use a few directives for WoWInterface uploading.
 
   - *wowi-archive-previous* : `yes|no` (defaults to yes) Archive the previous release.
-  - *wowi-create-changelog* : `yes|no` (defaults to yes) Generate a Git changelog using BBCode that will be set when uploading. A manual changelog will always be used if set in the .pkgmeta. If you have [cmark](https://github.com/jgm/cmark) installed, manual changelogs in Markdown format will be converted to BBCode; otherwise, the manual changelog will be used as-is.
+  - *wowi-create-changelog* : `yes|no` (defaults to yes) Generate a Git changelog using BBCode that will be set when uploading. A manual changelog will always be used if set in the .pkgmeta. If you have [pandoc](http://pandoc.org/) or [cmark](https://github.com/jgm/cmark) installed, manual changelogs in Markdown format will be converted to BBCode; otherwise, the manual changelog will be used as-is.
 
 __release.sh__ supports the following repository substitution keywords when
 copying the files from the checkout into the project directory. See the [CurseForge Knowledge base page](http://legacy.curseforge.com/wiki/repositories/repository-keyword-substitutions/) for more info.


### PR DESCRIPTION
- Only when the manual changelog uses Markdown
- Requires [cmark](https://github.com/jgm/cmark)

If the manual changelog isn't Markdown, or cmark isn't installed, the manual changelog is used as-is.

I used cmark as an intermediary to convert the Markdown to HTML first so there's a predictable, well-formed output to work with; using a million regexes to convert HTML to BBCode is bad enough, I didn't want to try to parse arbitrary Markdown directly that way. I'm fairly sure I caught all the HTML tags that exist in cmark output that can be sensibly converted to BBCode. Any remaining HTML tags after conversion are stripped out.

Example result here:
https://www.wowinterface.com/downloads/info21998#changelog