### PR TITLE
Strip CR from slug when read from TOC

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -250,6 +250,7 @@ if [ -f "$topdir/$tocfile" ]; then
 	# Grab CurseForge slug and WoWI ID from the TOC file.
 	if [ -z "$slug" ]; then
 		slug=$( awk '/## X-Curse-Project-ID:/ { print $NF }' < "$topdir/$tocfile" )
+		slug="${slug/$'\r'}"
 	fi
 	if [ -z "$addonid" ]; then
 		addonid=$( awk '/## X-WoWI-ID:/ { print $NF }' < "$topdir/$tocfile" )


### PR DESCRIPTION
Otherwise, if the TOC file has CRLF line endings, uploading to Curse fails with a curl error about invalid characters in the URL.

There's probably a more elegant way to do this, and it might be a good idea to strip carriage returns from everything read in from the TOC, but the Curse slug seems to be the only one where a CR actually affects anything.