### PR TITLE
Make the packager apply top-level ignore directives to externals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-# Backup files
-*.bak
-
-# Local extra files
-Extras/
-.release/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Backup files
+*.bak
+
+# Local extra files
+Extras/
+.release/

--- a/release.sh
+++ b/release.sh
@@ -1018,8 +1018,10 @@ copy_directory_tree() {
 		if [ -f "$_cdt_srcdir/$file" ]; then
 			# Check if the file should be ignored.
 			skip_copy=
+			_cdt_cropped_dir=${_cdt_destdir#$pkgdir/} # the cropped dir is the way a user would specify a path for an external to be excluded from packaging in the top-level pkgmeta file.
+
 			# Skip files matching the colon-separated "ignored" shell wildcard patterns.
-			if [ -z "$skip_copy" ] && match_pattern "$file" "$_cdt_ignored_patterns"; then
+			if [ -z "$skip_copy" ] && ( match_pattern "$file" "$_cdt_ignored_patterns" || match_pattern "$_cdt_cropped_dir/$file" "$_cdt_ignored_patterns" ); then
 				skip_copy=true
 			fi
 			# Never skip files that match the colon-separated "unchanged" shell wildcard patterns.

--- a/release.sh
+++ b/release.sh
@@ -1229,7 +1229,7 @@ checkout_external() {
 			fi
 		fi
 		# If a .pkgmeta file is present, process it for an "ignore" list.
-		ignore=
+		_cqe_specific_ignore=$ignore
 		if [ -f "$_cqe_checkout_dir/.pkgmeta" ]; then
 			yaml_eof=
 			while [ -z "$yaml_eof" ]; do
@@ -1255,10 +1255,10 @@ checkout_external() {
 							if [ -d "$_cqe_checkout_dir/$pattern" ]; then
 								pattern="$pattern/*"
 							fi
-							if [ -z "$ignore" ]; then
-								ignore="$pattern"
+							if [ -z "$_cqe_specific_ignore" ]; then
+								_cqe_specific_ignore="$pattern"
 							else
-								ignore="$ignore:$pattern"
+								_cqe_specific_ignore="$_cqe_specific_ignore:$pattern"
 							fi
 							;;
 						esac
@@ -1268,7 +1268,7 @@ checkout_external() {
 				esac
 			done < "$_cqe_checkout_dir/.pkgmeta"
 		fi
-		copy_directory_tree -dnp -i "$ignore" "$_cqe_checkout_dir" "$pkgdir/$_external_dir"
+		copy_directory_tree -dnp -i "$_cqe_specific_ignore" "$_cqe_checkout_dir" "$pkgdir/$_external_dir"
 	)
 	# Remove the ".checkout" subdirectory containing the full checkout.
 	if [ -d "$_cqe_checkout_dir" ]; then


### PR DESCRIPTION
This pull request is to allow the user more control over which files are ignored. Specifically, it allows the ignore directives in the user's .pkgmeta file to be applied to files downloaded via externals.

Sample test case: Create a basic addon with [this .pkgmeta file](https://github.com/BigWigsMods/packager/files/2152574/pkgmeta.txt), renamed appropriately.

With the packager as it currently works, you would get the following files in your Libs/Libstub folder:

- LibStub.lua
- LibStub.toc
- tests\test.lua
- tests\test2.lua
- tests\test3.lua
- tests\test4.lua

Note that both the tests directory and the .toc file for LibStub are packaged. This is because the packager resets the ignore list before getting each external.

The pull request modifies this behavior. Instead of resetting the ignore list for each external, it instead combines the ignore list for the external and the ignore list for the main addon. Thus, the end user can specify ignored files and directories in what would be downloaded from the external.

Going back to our test case, after applying this pull request, the Libs/LibStub folder only contains:

- LibStub.lua
