### PR TITLE
Add support for lightweight tags in externals

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1289,7 +1289,7 @@ checkout_external() {
 			git clone -q --depth 1 --branch "$_external_tag" "$_external_uri" "$_cqe_checkout_dir" || return 1
 		else # [ "$_external_tag" = "latest" ]; then
 			git clone -q --depth 50 "$_external_uri" "$_cqe_checkout_dir" || return 1
-			_external_tag=$( git -C "$_cqe_checkout_dir" for-each-ref refs/tags --sort=-taggerdate --format=%\(refname:short\) --count=1 )
+			_external_tag=$( git -C "$_cqe_checkout_dir" for-each-ref refs/tags --sort=-creatordate --format=%\(refname:short\) --count=1 )
 			if [ -n "$_external_tag" ]; then
 				echo "Fetching tag \"$_external_tag\" from external $_external_uri"
 				git -C "$_cqe_checkout_dir" checkout -q "$_external_tag"


### PR DESCRIPTION
Currently, if an external uses a mix of annotated and lightweight tags only the latest *annotated* tag would be pulled since lightweight tags don't have taggerdate metadata. Instead we can use creatordate, which is available on both types of tags.