### PR TITLE
don't use hardcoded shebang

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # release.sh generates a zippable addon directory from a Git or SVN checkout.
 #


### PR DESCRIPTION
this fixes a bunch of issues with mac having bash v3 as `/bin/bash` as it will use the configured `bash` without having to replace the `/bin/bash`.