### PR TITLE
Fix error when the absolute path to the build dir contains spaces

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1918,7 +1918,7 @@ if [ -f "$pkgmeta_file" ]; then
 						fi
 						# Check to see if the base source directory is empty
 						_mf_basedir=${srcdir%$(basename "$yaml_key")}
-						if [ ! "$(ls -A $_mf_basedir )" ]; then
+						if [ $(ls -A "$_mf_basedir" | wc -l) == 0 ]; then
 							echo "Removing empty directory ${_mf_basedir#$releasedir/}"
 							rm -fr "$_mf_basedir"
 						fi


### PR DESCRIPTION
The empty dir check after moving folders wasn't quoting the path, so it would error if the path contained spaces.