### PR TITLE
Fix curl errors for CF uploads with a large changelog

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2107,16 +2107,12 @@ if [ -z "$skip_zipfile" ]; then
 			_cf_payload=$( echo "$_cf_payload $_cf_payload_relations" | jq -s -c '.[0] * .[1]' )
 		fi
 
-		# Put payload into a file to avoid "curl: Argument list too long"
-		_cf_payload_file="$releasedir/.${RANDOM}.cfmetapayload"
-		echo $_cf_payload > "$_cf_payload_file"
-		
 		echo "Uploading $archive_name ($game_version $file_type) to $project_site/projects/$slug"
 		resultfile="$releasedir/cf_result.json"
-		result=$( curl -sS --retry 3 --retry-delay 10 \
+		result=$( echo "$_cf_payload" | curl -sS --retry 3 --retry-delay 10 \
 				-w "%{http_code}" -o "$resultfile" \
 				-H "x-api-token: $cf_token" \
-				-F "metadata=<$_cf_payload_file" \
+				-F "metadata=<-" \
 				-F "file=@$archive" \
 				"$project_site/api/projects/$slug/upload-file" ) &&
 		{
@@ -2144,7 +2140,6 @@ if [ -z "$skip_zipfile" ]; then
 		}
 		echo
 
-		rm -f "$_cf_payload_file" 2>/dev/null
 		rm -f "$resultfile" 2>/dev/null
 	fi
 

--- a/release.sh
+++ b/release.sh
@@ -2107,12 +2107,16 @@ if [ -z "$skip_zipfile" ]; then
 			_cf_payload=$( echo "$_cf_payload $_cf_payload_relations" | jq -s -c '.[0] * .[1]' )
 		fi
 
+		# Put payload into a file to avoid "curl: Argument list too long"
+		_cf_payload_file="$releasedir/.${RANDOM}.cfmetapayload"
+		echo $_cf_payload > "$_cf_payload_file"
+		
 		echo "Uploading $archive_name ($game_version $file_type) to $project_site/projects/$slug"
 		resultfile="$releasedir/cf_result.json"
 		result=$( curl -sS --retry 3 --retry-delay 10 \
 				-w "%{http_code}" -o "$resultfile" \
 				-H "x-api-token: $cf_token" \
-				-F "metadata=$_cf_payload" \
+				-F "metadata=<$_cf_payload_file" \
 				-F "file=@$archive" \
 				"$project_site/api/projects/$slug/upload-file" ) &&
 		{
@@ -2140,6 +2144,7 @@ if [ -z "$skip_zipfile" ]; then
 		}
 		echo
 
+		rm -f "$_cf_payload_file" 2>/dev/null
 		rm -f "$resultfile" 2>/dev/null
 	fi
 


### PR DESCRIPTION
The `curl` call for the Curseforge upload will fail if the metadata payload is too big (which can happen if you maintain a manual changelog that has grown really big over many years, since the metadata contains the raw changelog).

Changed it to pull from a file instead. Verified that it works properly (https://www.curseforge.com/wow/addons/tellmewhen/files/2761465).