### PR TITLE
Improve untracked/ignored file handling (git)

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -720,14 +720,20 @@ fi
 
 # Add untracked/ignored files to the ignore list
 if [ "$repository_type" = "git" ]; then
-	_vcs_ignore=$( git -C "$topdir" ls-files --others | sed -e ':a' -e 'N' -e 's/\n/:/' -e 'ta' )
-	if [ -n "$_vcs_ignore" ]; then
+	OLDIFS=$IFS
+	IFS=$'\n'
+	 for _vcs_ignore in $(git -C "$topdir" ls-files --others --directory); do
+		if [ -d "$topdir/$_vcs_ignore" ]; then
+			_vcs_ignore="$_vcs_ignore*"
+		fi
+
 		if [ -z "$ignore" ]; then
 			ignore="$_vcs_ignore"
 		else
 			ignore="$ignore:$_vcs_ignore"
 		fi
-	fi
+	done
+	IFS=$OLDIFS
 elif [ "$repository_type" = "svn" ]; then
 	# svn always being difficult.
 	OLDIFS=$IFS


### PR DESCRIPTION
Untracked file lists generated by `git ls-files` can slow down the packager if the project directory contains an untracked folder with a *lot* of files. My case here was I had a `.cache` directory with some ~28,000 files for database generation which would cause the packager to take well over an hour to execute if I didn't move the directory outside the tree first.

The `git ls-files` command supports a `--directory` option which will cause it to list the name of a directory with a trailing slash if all files within the directory are ignored. This fixes performance issues in the above edge case.

I've tested this with a mix of partially and fully untracked directories, and verified nothing that shouldn't be picked up sneaks into the packaged zips.