### PR TITLE
Add workflow to push image to GitHub registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Authenticate with registry and build image
         run: |
-          echo "${{ secrets.DOCKER_PASS }}" | docker login docker.pkg.github.com -u "nebularg" --password-stdin
+          docker login docker.pkg.github.com -u "nebularg" -p "${{ secrets.DOCKER_PASS }}"
           docker build -t packager .
 
       - name: Tag and push latest image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Build and tag image
         run: |
           docker build . \
-            -t docker.pkg.github.com/BigWigsMods/packager/packager:${GITHUB_SHA::7} \
-            -t docker.pkg.github.com/BigWigsMods/packager/packager:latest
+            -t docker.pkg.github.com/bigwigsmods/packager/packager:${GITHUB_SHA::7} \
+            -t docker.pkg.github.com/bigwigsmods/packager/packager:latest
       - name: Push image
         run: |
           echo "${{ secrets.DOCKER_PASS }}" | docker login docker.pkg.github.com -u "nebularg" --password-stdin
-          docker push docker.pkg.github.com/BigWigsMods/packager/packager:${GITHUB_SHA::7}
-          docker push docker.pkg.github.com/BigWigsMods/packager/packager:latest
+          docker push docker.pkg.github.com/bigwigsmods/packager/packager:${GITHUB_SHA::7}
+          docker push docker.pkg.github.com/bigwigsmods/packager/packager:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,20 @@
+name: Build and push image to repository
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build and tag image
+        run: |
+          docker build . \
+            -t docker.pkg.github.com/BigWigsMods/packager/packager:${GITHUB_SHA::7} \
+            -t docker.pkg.github.com/BigWigsMods/packager/packager:latest
+      - name: Push image
+        run: |
+          echo "${{ secrets.DOCKER_PASS }}" | docker login docker.pkg.github.com -u "nebularg" --password-stdin
+          docker push docker.pkg.github.com/BigWigsMods/packager/packager:${GITHUB_SHA::7}
+          docker push docker.pkg.github.com/BigWigsMods/packager/packager:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - release.sh
+      - Dockerfile
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,13 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Build and tag image
-        run: |
-          docker build . \
-            -t docker.pkg.github.com/bigwigsmods/packager/packager:${GITHUB_SHA::7} \
-            -t docker.pkg.github.com/bigwigsmods/packager/packager:latest
-      - name: Push image
+      - name: Authenticate with registry and build image
         run: |
           echo "${{ secrets.DOCKER_PASS }}" | docker login docker.pkg.github.com -u "nebularg" --password-stdin
-          docker push docker.pkg.github.com/bigwigsmods/packager/packager:${GITHUB_SHA::7}
+          docker build -t packager .
+
+      - name: Tag and push latest image
+        run: |
+          docker tag packager docker.pkg.github.com/bigwigsmods/packager/packager:latest
           docker push docker.pkg.github.com/bigwigsmods/packager/packager:latest
+      
+      - name: Tag and push nightly image
+        run: |
+          TAG="$(date -u +%Y%m%d%H%M%S)"
+          docker tag packager docker.pkg.github.com/bigwigsmods/packager/packager:$TAG
+          docker push docker.pkg.github.com/bigwigsmods/packager/packager:$TAG

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Authenticate with registry and build image
         run: |
-          docker login docker.pkg.github.com -u "nebularg" -p "${{ secrets.DOCKER_PASS }}"
+          docker login docker.pkg.github.com -u "BigWigsMods" -p "${{ secrets.DOCKER_PASS }}"
           docker build -t packager .
 
       - name: Tag and push latest image


### PR DESCRIPTION
This PR will add a new Action workflow that builds, tags and pushes a new Docker image to the repo on every push to the master branch.

It will create two tags, once named `latest`, and one named by the first 7 letters of the commit SHA (also known as a short-SHA). The latter tag is there in case people want to lock themselves to a specific commit, since you're not versioning this project.

For this to work you'll need to create a new [access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) with the scopes "read", "read:packages" and "write:packages".  
To use this access token, visit the [secrets](https://github.com/BigWigsMods/packager/settings/secrets) settings page and create a new secret named `DOCKER_PASS` and paste in the access token as the value (make sure there are no leading/trailing spaces!).

Once that is in place (before merging this PR) and the PR is merged, everything should work just fine. I tested this in a separate fork, and you can see the results of this here:
- Example run from a commit: [p3lim/packager-repo-test/runs/246980815](https://github.com/p3lim/packager-repo-test/runs/246980815)
- Packages: [p3lim/packager-repo-test/packages/30844](https://github.com/p3lim/packager-repo-test/packages/30844)
