### PR TITLE
Add support for GitHub actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,11 +3,6 @@ description: Builds and publishes World of Warcraft AddOns
 branding:
   icon: package
   color: yellow
-inputs:
-  options:
-    description: Arguments passed to release.sh
-    required: false
 runs:
   using: docker
   image: Dockerfile
-  args: release.sh ${{ inputs.options }}

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,13 @@ description: Builds and publishes World of Warcraft AddOns
 branding:
   icon: package
   color: yellow
+inputs:
+  options:
+    description: Arguments passed to release.sh
+    required: false
 runs:
   using: docker
   image: Dockerfile
   args:
     - release.sh
-    - $INPUT_ARGS
+    - ${{ inputs.options }}

--- a/action.yml
+++ b/action.yml
@@ -8,3 +8,4 @@ runs:
   image: Dockerfile
   args:
     - release.sh
+    - $INPUT_ARGS

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
-  args: ['release.sh', '${{ inputs.options }}']
+  args: release.sh ${{ inputs.options }}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,10 @@
+name: WoW Release
+description: Builds and publishes World of Warcraft AddOns
+branding:
+  icon: package
+  color: yellow
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - release.sh

--- a/action.yml
+++ b/action.yml
@@ -6,4 +6,3 @@ branding:
 runs:
   using: docker
   image: Dockerfile
-  entrypoint: release.sh

--- a/action.yml
+++ b/action.yml
@@ -6,3 +6,4 @@ branding:
 runs:
   using: docker
   image: Dockerfile
+  entrypoint: release.sh

--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,4 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - release.sh
-    - ${{ inputs.options }}
+    - release.sh ${{ inputs.options }}

--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,4 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
-  args:
-    - release.sh ${{ inputs.options }}
+  args: ['release.sh', '${{ inputs.options }}']


### PR DESCRIPTION
This will allow people to use the packager with [GitHub Actions](https://github.com/features/actions) themselves, without messing with `curl` or Docker.

Usage:

1. create a new workflow (e.g. `.github/workflows/release.yml`)
2. configure workflow
	```yaml
	name: Release new AddOn version (or whatever, this string you can customize)
	on:
	  push:
	    tags:
	      - '**'
	jobs:
	  release:
	    runs-on: ubuntu-latest
	    steps:
	      # pull the repository (required)
	      - uses: actions/checkout@v1

	      # run release.sh without any arguments (default)
	      - uses: BigWigsMods/packager@master

	      # run release.sh with arguments
	      - uses: BigWigsMods/packager@master
	        with:
	          args: release.sh -g 1.13.2 -w 0

	      # use a specific version of release.sh (short-SHA)
	      - uses: BigWigsMods/packager@9a689b3
	    env:
	      CF_API_KEY: ${{ secrets.CF_API_KEY }}
	      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
	```
3. [create secrets](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) that'll hold the API keys/tokens for pushing to CurseForge/WoWI/GitHub

I wasn't able to deal with custom parameters better than this (the args example above) without modifying the Docker image, making the image harder to use for people _not_ using Actions.

Also, if you want this to exist on the [marketplace](https://github.com/marketplace?type=actions) you'll need to create releases and therefore use tags, so that's up to you if you want the banner when people visit the repo as well as being indexed on the marketplace.