### PR TITLE
Add -t option to skip TravisCI branch checks

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -877,6 +877,7 @@ contents="$package"
 # Filter for simple repository keyword replacement.
 simple_filter() {
 	sed \
+		-e "s/@travis-build-number@/$TRAVIS_BUILD_NUMBER/g" \
 		-e "s/@project-revision@/$si_project_revision/g" \
 		-e "s/@project-hash@/$si_project_hash/g" \
 		-e "s/@project-abbreviated-hash@/$si_project_abbreviated_hash/g" \


### PR DESCRIPTION
I use GitFlow at when i have a big release coming up. As such being able to generate alphas on my develop branch is needed at times.  The addition of this switch would keep me from having to maintain a separate version of the script.

I also added a @travis-build-number@ variable as with alpha builds users have an easier time conveying a simple build number like '345' than the git hash of '852c27b'