### PR TITLE
Git submodule support

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1413,12 +1413,12 @@ checkout_external() {
 	if [ "$_external_type" = "git" ]; then
 		if [ -z "$_external_tag" ]; then
 			echo "Fetching latest version of external $_external_uri"
-			git clone -q --depth 1 "$_external_uri" "$_cqe_checkout_dir" || return 1
+			git clone -q --recursive --depth 1 "$_external_uri" "$_cqe_checkout_dir" || return 1
 		elif [ "$_external_tag" != "latest" ]; then
 			echo "Fetching tag \"$_external_tag\" from external $_external_uri"
-			git clone -q --depth 1 --branch "$_external_tag" "$_external_uri" "$_cqe_checkout_dir" || return 1
+			git clone -q --recursive --depth 1 --branch "$_external_tag" "$_external_uri" "$_cqe_checkout_dir" || return 1
 		else # [ "$_external_tag" = "latest" ]; then
-			git clone -q --depth 50 "$_external_uri" "$_cqe_checkout_dir" || return 1
+			git clone -q --recursive --depth 50 "$_external_uri" "$_cqe_checkout_dir" || return 1
 			_external_tag=$( git -C "$_cqe_checkout_dir" for-each-ref refs/tags --sort=-creatordate --format=%\(refname:short\) --count=1 )
 			if [ -n "$_external_tag" ]; then
 				echo "Fetching tag \"$_external_tag\" from external $_external_uri"


### PR DESCRIPTION
Example of submodules in use: [MaxDPS](https://github.com/kaminaris/MaxDps/tree/master/Libs) has StdUi as a submodule  or [SpartanUI](https://github.com/Wutname1/SpartanUI/tree/master/libs) has SUF and StdUi as submodules with this PR no reference is needed in the pkgmeta git handles getting all the files and most importantly ensures the proper commit is used. 

There is no harm in using recursive when no submodules are present git just ignores it.