### PR TITLE
Mac fix: Add relative folder for grep -r

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -914,7 +914,7 @@ set_localization_url() {
 	if [ -n "$slug" ] && [ -n "$cf_token" ] && [ -n "$project_site" ]; then
 		localization_url="${project_site}/api/projects/$slug/localization/export"
 	fi
-	if [ -z "$localization_url" ] && grep -rq --include="*.lua" "@localization"; then
+	if [ -z "$localization_url" ] && grep -rq --include="*.lua" "@localization" .; then
 		echo "Skipping localization! Missing CurseForge API token and/or project id is invalid."
 		echo
 	fi

--- a/release.sh
+++ b/release.sh
@@ -914,7 +914,7 @@ set_localization_url() {
 	if [ -n "$slug" ] && [ -n "$cf_token" ] && [ -n "$project_site" ]; then
 		localization_url="${project_site}/api/projects/$slug/localization/export"
 	fi
-	if [ -z "$localization_url" ] && grep -rq --include="*.lua" "@localization" .; then
+	if [ -z "$localization_url" ] && grep -rq --include="*.lua" "@localization" "$topdir"; then
 		echo "Skipping localization! Missing CurseForge API token and/or project id is invalid."
 		echo
 	fi


### PR DESCRIPTION
This allows the release.sh to work correctly on Mac:

```
$ bash --version
GNU bash, version 5.0.16(1)-release (x86_64-apple-darwin19.3.0)

$ grep --version
grep (BSD grep) 2.5.1-FreeBSD
```

```sh
$ ./release.sh -d -z

Packaging LibClassicSpecs
Current version: 0.9.2-8-ge221e4e
Previous version: 0.9.2
Build type: non-retail alpha non-debug

CurseForge ID: 363313
WoWInterface ID: 25508
GitHub: tstirrat/LibClassicSpecs

Checkout directory: /Users/tstirrat/dev/LibClassicSpecs
Release directory: /Users/tstirrat/dev/LibClassicSpecs/.release

grep: warning: recursive search of stdin
^C # it stalls here
```