### PR TITLE
Add gawk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # install dependencies
-RUN apk add --no-cache bash curl grep zip jq git subversion mercurial
+RUN apk add --no-cache bash curl grep zip jq git subversion mercurial gawk
 RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ pandoc
 
 # copy release.sh


### PR DESCRIPTION
Add gawk to the Alpine environment to fix the packager script syntax error when using the Alpine standard awk.

I've tested it and it does fix the issue.

Fixes #58.