### PR TITLE
Don't append classic, if classic is in the package name

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2085,7 +2085,7 @@ if [ -z "$skip_zipfile" ]; then
 	archive_package_name="${package//[^A-Za-z0-9._-]/_}"
 
 	classic_tag=
-	if [[ -n "$classic" && "${project_version,,}" != *"classic"* ]]; then
+	if [[ -n "$classic" && ("${archive_package_name,,}" != *"classic"* || ${project_version,,}" != *"classic"*) ]]; then
 		# if it's a classic build, and classic isn't in the name, append it for clarity
 		classic_tag="-classic"
 	fi


### PR DESCRIPTION
My addon ThreatClassic2 has classic right in the name. The packager only checks for classic in the version, but not in the package name and thus creates "ThreatClassic2-v2.28-classic". This patch prevents this.

An alternative approach would be a CLI option to disable this functionality altogether.