### PR TITLE
Use distinct TOC files

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -963,6 +963,27 @@ if [[ ! -f "$topdir/$toc_path" && -f "$topdir/$package/$toc_path" ]]; then
 	toc_path="$package/$toc_path"
 fi
 
+# Use distinct TOC file if it exists
+if [[ "$game_type" == "classic" ]]; then
+	if [[ -f "$topdir/$package-Classic.toc" ]]; then
+		toc_path="$package-Classic.toc"
+	elif [[ ! -f "$topdir/$package-Classic.toc" && -f "$topdir/$package/$package-Classic.toc" ]]; then
+		toc_path="$package/$package-Classic.toc"
+	fi
+elif [[ "$game_type" == "bcc" ]]; then
+	if [[ -f "$topdir/$package-BCC.toc" ]]; then
+		toc_path="$package-BCC.toc"
+	elif [[ ! -f "$topdir/$package-BCC.toc" && -f "$topdir/$package/$package-BCC.toc" ]]; then
+		toc_path="$package/$package-BCC.toc"
+	fi
+elif [[ "$game_type" == "retail" ]]; then
+	if [[ -f "$topdir/$package-Mainline.toc" ]]; then
+		toc_path="$package-Mainline.toc"
+	elif [[ ! -f "$topdir/$package-Mainline.toc" && -f "$topdir/$package/$package-Mainline.toc" ]]; then
+		toc_path="$package/$package-Mainline.toc"
+	fi
+fi
+
 if [[ ! -f "$topdir/$toc_path" ]]; then
 	echo "Could not find an addon TOC file. In another directory? Make sure it matches the 'package-as' in .pkgmeta" >&2
 	exit 1


### PR DESCRIPTION
This fixes an issue where the packager fails to run when specifying game version and using [distinct TOC files](https://github.com/Stanzilla/WoWUIBugs/issues/68#issuecomment-830351390):
```bash
> cat Addon-Classic.toc
## Interface: 11307
...

> ./release.sh -g classic
Addon TOC interface version is not compatible with the game version "classic" or was not found.
```
