### PR TITLE
Update regular expressions for new TOC suffixes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -951,7 +951,7 @@ if [[ -z "$package" ]]; then
 		exit 1
 	fi
 	package=${package%.toc}
-	if [[ $package =~ ^(.*)(-(Mainline|Classic|BCC)|_(Mainline|Vanilla|TBC))$ ]]; then
+	if [[ $package =~ ^(.*)[_-](Mainline|Classic|Vanilla|BCC|TBC)$ ]]; then
 		package="${BASH_REMATCH[1]}"
 	fi
 fi
@@ -1499,7 +1499,7 @@ copy_directory_tree() {
 							_cdt_filters+="|toc_filter version-retail ${_cdt_classic:+true}"
 							_cdt_filters+="|toc_filter version-classic $([[ -z "$_cdt_classic" || "$_cdt_classic" == "bcc" ]] && echo "true")"
 							_cdt_filters+="|toc_filter version-bcc $([[ -z "$_cdt_classic" || "$_cdt_classic" == "classic" ]] && echo "true")"
-							[[ -z "$_cdt_external" && ! $file =~ (-(Mainline|Classic|BCC)|_(Mainline|Vanilla|TBC)).toc$ ]] && _cdt_filters+="|toc_interface_filter"
+							[[ -z "$_cdt_external" && ! $file =~ [_-](Mainline|Classic|Vanilla|BCC|TBC).toc$ ]] && _cdt_filters+="|toc_interface_filter"
 							[ -n "$_cdt_localization" ] && _cdt_filters+="|localization_filter"
 							;;
 					esac

--- a/release.sh
+++ b/release.sh
@@ -951,7 +951,7 @@ if [[ -z "$package" ]]; then
 		exit 1
 	fi
 	package=${package%.toc}
-	if [[ $package =~ ^(.*)-(Mainline|Classic|BCC)$ ]]; then
+	if [[ $package =~ ^(.*)(-(Mainline|Classic|BCC)|_(Mainline|Vanilla|TBC))$ ]]; then
 		package="${BASH_REMATCH[1]}"
 	fi
 fi
@@ -1499,7 +1499,7 @@ copy_directory_tree() {
 							_cdt_filters+="|toc_filter version-retail ${_cdt_classic:+true}"
 							_cdt_filters+="|toc_filter version-classic $([[ -z "$_cdt_classic" || "$_cdt_classic" == "bcc" ]] && echo "true")"
 							_cdt_filters+="|toc_filter version-bcc $([[ -z "$_cdt_classic" || "$_cdt_classic" == "classic" ]] && echo "true")"
-							[[ -z "$_cdt_external" && ! $file =~ -(Mainline|Classic|BCC).toc$ ]] && _cdt_filters+="|toc_interface_filter"
+							[[ -z "$_cdt_external" && ! $file =~ (-(Mainline|Classic|BCC)|_(Mainline|Vanilla|TBC)).toc$ ]] && _cdt_filters+="|toc_interface_filter"
 							[ -n "$_cdt_localization" ] && _cdt_filters+="|localization_filter"
 							;;
 					esac


### PR DESCRIPTION
Future client builds will be supporting an additional set of suffixes for per-client TOC files; `Addon_Vanilla.toc` and `Addon_TBC.toc`. Additionally the separator between the addon name and the client identifier can be either an underscore or a hyphen. The existing suffixes will remain supported and shouldn't be removed.

This change hasn't been extensively tested, but I did smoke test a quick dummy addon and verified that the package name inferred from TOC filenames is correct in the presence of the new suffixes. Haven't verified that the processing of externals with the new suffix works, since it's hot off the press and all.