### PR TITLE
Preliminary 3.4.0 Support

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2633,6 +2633,10 @@ upload_wowinterface() {
 			version="${game_type_version[$type]}"
 			# check the version
 			if ! jq -e --arg v "$version" 'map(select(.id == $v)) | length > 0' <<< "$_wowi_versions" &>/dev/null; then
+				if [[ $type == "wrath" ]]; then # XXX compat
+					echo "WARNING: Wrath is currently unsupported by WoWInterface, falling back to BCC" >&2
+					version="2.5.10"
+				fi
 				# split out the versions that match the version we're checking against (to keep things more readable)
 				_wowi_versions_type=$( echo "$_wowi_versions" | jq -c --arg v "$version" 'map(select( (.id | .[:2]) == ($v | .[:2]) ))' )
 				if [[ $_wowi_versions_type == "[]" ]]; then

--- a/release.sh
+++ b/release.sh
@@ -214,8 +214,8 @@ while getopts ":celLzusSop:dw:a:r:t:g:m:n:" opt; do
 							game_type="classic"
 						elif [[ ${BASH_REMATCH[1]} == "2" ]]; then
 							game_type="bcc"
-                        elif [[ ${BASH_REMATCH[1]} == "3" ]]; then
-                            game_type="wrath"
+						elif [[ ${BASH_REMATCH[1]} == "3" ]]; then
+							game_type="wrath"
 						else
 							game_type="retail"
 						fi
@@ -1044,7 +1044,7 @@ do_toc() {
 		"") toc_game_type= ;;
 		11*) toc_game_type="classic" ;;
 		20*) toc_game_type="bcc" ;;
-        30*) toc_game_type="wrath" ;;
+		30*) toc_game_type="wrath" ;;
 		*) toc_game_type="retail"
 	esac
 	si_game_type_interface=()
@@ -1101,7 +1101,7 @@ do_toc() {
 			case $toc_version in
 				11*) toc_game_type="classic" ;;
 				20*) toc_game_type="bcc" ;;
-                30*) toc_game_type="wrath" ;;
+				30*) toc_game_type="wrath" ;;
 				*) toc_game_type="retail"
 			esac
 		fi
@@ -1112,7 +1112,7 @@ do_toc() {
 			case $toc_game_type in
 				classic) toc_version=$( sed -n '/@non-[-a-z]*@/,/@end-non-[-a-z]*@/{//b;p}' <<< "$toc_file" | awk '/#[[:blank:]]*## Interface:[[:blank:]]*(11)/ { print $NF; exit }' ) ;;
 				bcc) toc_version=$( sed -n '/@non-[-a-z]*@/,/@end-non-[-a-z]*@/{//b;p}' <<< "$toc_file" | awk '/#[[:blank:]]*## Interface:[[:blank:]]*(20)/ { print $NF; exit }' ) ;;
-                wrath) toc_version=$( sed -n '/@non-[-a-z]*@/,/@end-non-[-a-z]*@/{//b;p}' <<< "$toc_file" | awk '/#[[:blank:]]*## Interface:[[:blank:]]*(30)/ { print $NF; exit }' ) ;;
+				wrath) toc_version=$( sed -n '/@non-[-a-z]*@/,/@end-non-[-a-z]*@/{//b;p}' <<< "$toc_file" | awk '/#[[:blank:]]*## Interface:[[:blank:]]*(30)/ { print $NF; exit }' ) ;;
 			esac
 			# This becomes the actual interface version after replacements
 			root_toc_version="$toc_version"
@@ -1154,7 +1154,7 @@ set_build_version() {
 				case $toc_version in
 					11*) toc_game_type="classic" ;;
 					20*) toc_game_type="bcc" ;;
-                    30*) toc_game_type="wrath" ;;
+					30*) toc_game_type="wrath" ;;
 					*) toc_game_type="retail"
 				esac
 				if [[ -z $game_type || $game_type == "$toc_game_type" ]]; then
@@ -1668,7 +1668,7 @@ copy_directory_tree() {
 							[ "$_cdt_gametype" != "retail" ] && _cdt_filters+="|lua_filter version-retail|lua_filter retail"
 							[ "$_cdt_gametype" != "classic" ] && _cdt_filters+="|lua_filter version-classic"
 							[ "$_cdt_gametype" != "bcc" ] && _cdt_filters+="|lua_filter version-bcc"
-                            [ "$_cdt_gametype" != "wrath" ] && _cdt_filters+="|lua_filter version-wrath"
+							[ "$_cdt_gametype" != "wrath" ] && _cdt_filters+="|lua_filter version-wrath"
 							[ -n "$_cdt_localization" ] && _cdt_filters+="|localization_filter"
 							;;
 						*.xml)
@@ -1679,7 +1679,7 @@ copy_directory_tree() {
 							[ "$_cdt_gametype" != "retail" ] && _cdt_filters+="|xml_filter version-retail|xml_filter retail"
 							[ "$_cdt_gametype" != "classic" ] && _cdt_filters+="|xml_filter version-classic"
 							[ "$_cdt_gametype" != "bcc" ] && _cdt_filters+="|xml_filter version-bcc"
-                            [ "$_cdt_gametype" != "wrath" ] && _cdt_filters+="|xml_filter version-wrath"
+							[ "$_cdt_gametype" != "wrath" ] && _cdt_filters+="|xml_filter version-wrath"
 							;;
 						*.toc)
 							# We only care about processing project TOC files
@@ -1691,7 +1691,7 @@ copy_directory_tree() {
 									case ${toc_root_interface["$_cdt_srcdir/$file"]} in
 										11*) _cdt_gametype="classic" ;;
 										20*) _cdt_gametype="bcc" ;;
-                                        30*) _cdt_gametype="wrath" ;;
+										30*) _cdt_gametype="wrath" ;;
 										*) _cdt_gametype="retail"
 									esac
 								fi
@@ -1703,7 +1703,7 @@ copy_directory_tree() {
 								_cdt_filters+="|toc_filter version-retail $([[ "$_cdt_gametype" != "retail" ]] && echo "true")"
 								_cdt_filters+="|toc_filter version-classic $([[ "$_cdt_gametype" != "classic" ]] && echo "true")"
 								_cdt_filters+="|toc_filter version-bcc $([[ "$_cdt_gametype" != "bcc" ]] && echo "true")"
-                                _cdt_filters+="|toc_filter version-wrath $([[ "$_cdt_gametype" != "wrath" ]] && echo "true")"
+								_cdt_filters+="|toc_filter version-wrath $([[ "$_cdt_gametype" != "wrath" ]] && echo "true")"
 								_cdt_filters+="|toc_interface_filter '${si_game_type_interface_all[${_cdt_gametype:- }]}' '${toc_root_interface["$_cdt_srcdir/$file"]}'"
 								[ -n "$_cdt_localization" ] && _cdt_filters+="|localization_filter"
 							fi
@@ -1740,7 +1740,7 @@ copy_directory_tree() {
 								retail) new_file+="_Mainline.toc" ;;
 								classic) new_file+="_Vanilla.toc" ;;
 								bcc) new_file+="_TBC.toc" ;;
-                                wrath) new_file+="_Wrath.toc" ;;
+								wrath) new_file+="_Wrath.toc" ;;
 							esac
 
 							echo "    Creating $new_file [$toc_version]"
@@ -1754,7 +1754,7 @@ copy_directory_tree() {
 							_cdt_filters+="|toc_filter version-retail $([[ "$type" != "retail" ]] && echo "true")"
 							_cdt_filters+="|toc_filter version-classic $([[ "$type" != "classic" ]] && echo "true")"
 							_cdt_filters+="|toc_filter version-bcc $([[ "$type" != "bcc" ]] && echo "true")"
-                            _cdt_filters+="|toc_filter version-wrath $([[ "$type" != "wrath" ]] && echo "true")"
+							_cdt_filters+="|toc_filter version-wrath $([[ "$type" != "wrath" ]] && echo "true")"
 							_cdt_filters+="|toc_interface_filter '$toc_version' '$root_toc_version'"
 							_cdt_filters+="|line_ending_filter"
 
@@ -2516,7 +2516,11 @@ upload_curseforge() {
 				retail) _cf_game_type_id=517 ;;
 				classic) _cf_game_type_id=67408 ;;
 				bcc) _cf_game_type_id=73246 ;;
-                wrath) _cf_game_type_id=73246 ;; # TODO: Replace this ID when CF API updates
+				wrath)
+					# TODO: Replace this section when CF API updates
+					echo "WARNING: Wrath is currently unsupported in CurseForge, falling back to BCC"
+					_cf_game_type_id=73246
+					;;
 				*) _cf_game_type_id=517 # retail fallback
 			esac
 			_cf_game_version_id=$( echo "$_cf_versions" | jq -c --argjson v "$_cf_game_type_id" 'map(select(.gameVersionTypeID == $v)) | max_by(.id) | [.id]' 2>/dev/null )

--- a/release.sh
+++ b/release.sh
@@ -74,7 +74,7 @@ if [[ ${BASH_VERSINFO[0]} -lt 4 ]] || [[ ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VER
 fi
 
 # Game versions for uploading
-declare -A game_flavor=( ["retail"]="retail" ["classic"]="classic" ["bcc"]="bcc" ["mainline"]="retail" ["tbc"]="bcc" ["vanilla"]="classic" ["wrath"]="wrath" )
+declare -A game_flavor=( ["retail"]="retail" ["classic"]="classic" ["bcc"]="bcc" ["mainline"]="retail" ["tbc"]="bcc" ["vanilla"]="classic" ["wrath"]="wrath" ["wotlkc"]="wrath" )
 
 declare -A game_type_version=()           # type -> version
 declare -A game_type_interface=()         # type -> toc
@@ -1063,7 +1063,7 @@ do_toc() {
 
 	root_toc_version="$toc_version"
 
-	if [[ ${toc_name} =~ "$package_name"[-_](Mainline|Classic|Vanilla|BCC|TBC|Wrath)\.toc$ ]]; then
+	if [[ ${toc_name} =~ "$package_name"[-_](Mainline|Classic|Vanilla|BCC|TBC|Wrath|WOTLKC)\.toc$ ]]; then
 		# Flavored
 		if [[ -z "$toc_version" ]]; then
 			echo "$toc_name is missing an interface version." >&2
@@ -1197,14 +1197,14 @@ if [[ -z "$package" ]]; then
 		exit 1
 	fi
 	package=${package%.toc}
-	if [[ $package =~ ^(.*)([-_](Mainline|Classic|Vanilla|BCC|TBC|Wrath))$ ]]; then
+	if [[ $package =~ ^(.*)([-_](Mainline|Classic|Vanilla|BCC|TBC|Wrath|WOTLKC))$ ]]; then
 		echo "Ambiguous addon name. No fallback TOC file or addon name includes an expansion suffix (${BASH_REMATCH[2]}). Set 'package-as' in .pkgmeta" >&2
 		exit 1
 	fi
 fi
 
 # Parse the project root TOC files for info first
-for toc_path in "$topdir/$package"{,-Mainline,_Mainline,-Classic,_Classic,-Vanilla,_Vanilla,-BCC,_BCC,-TBC,_TBC,-Wrath,_Wrath}.toc; do
+for toc_path in "$topdir/$package"{,-Mainline,_Mainline,-Classic,_Classic,-Vanilla,_Vanilla,-BCC,_BCC,-TBC,_TBC,-Wrath,_Wrath,-WOTLKC,_WOTLKC}.toc; do
 	if [[ -f "$toc_path" ]]; then
 		set_toc_project_info "$toc_path"
 		toc_root_paths["$topdir"]="$package"
@@ -1220,7 +1220,7 @@ done
 
 # Parse project TOC files
 for path in "${!toc_root_paths[@]}"; do
-	for toc_path in "$path/${toc_root_paths[$path]}"{,-Mainline,_Mainline,-Classic,_Classic,-Vanilla,_Vanilla,-BCC,_BCC,-TBC,_TBC,-Wrath,_Wrath}.toc; do
+	for toc_path in "$path/${toc_root_paths[$path]}"{,-Mainline,_Mainline,-Classic,_Classic,-Vanilla,_Vanilla,-BCC,_BCC,-TBC,_TBC,-Wrath,_Wrath,-WOTLKC,_WOTLKC}.toc; do
 		if [[ -f "$toc_path" ]]; then
 			set_toc_project_info "$toc_path"
 			do_toc "$toc_path" "${toc_root_paths[$path]}"
@@ -2742,6 +2742,7 @@ upload_wago() {
 			version="${game_type_version[$type]}"
 			wago_type="$type"
 			[[ "$wago_type" == "bcc" ]] && wago_type="bc"
+			[[ "$wago_type" == "wrath" ]] && wago_type="wotlk"
 			# check the version
 			if ! jq -e --arg t "$wago_type" --arg v "$version" '.[$t] | index($v)' <<< "$_wago_versions" &>/dev/null; then
 				# no match, so grab the next highest version (try to avoid testing versions)

--- a/release.sh
+++ b/release.sh
@@ -2740,9 +2740,11 @@ upload_wago() {
 		local version wago_type
 		for type in "${!game_type_version[@]}"; do
 			version="${game_type_version[$type]}"
-			wago_type="$type"
-			[[ "$wago_type" == "bcc" ]] && wago_type="bc"
-			[[ "$wago_type" == "wrath" ]] && wago_type="wotlk"
+			case $type in
+				bcc) wago_type="bc" ;;
+				wrath) wago_type="wotlk" ;;
+				*) wago_type="$type"
+			esac
 			# check the version
 			if ! jq -e --arg t "$wago_type" --arg v "$version" '.[$t] | index($v)' <<< "$_wago_versions" &>/dev/null; then
 				# no match, so grab the next highest version (try to avoid testing versions)

--- a/release.sh
+++ b/release.sh
@@ -2525,11 +2525,7 @@ upload_curseforge() {
 			case $type in
 				classic) game_id=67408 ;;
 				bcc) game_id=73246 ;;
-				wrath)
-					# TODO: Replace this section when CF API updates
-					echo "WARNING: Wrath is currently unsupported in CurseForge, falling back to BCC"
-					game_id=73246
-					;;
+				wrath) game_id=73713 ;;
 				*) game_id=517
 			esac
 


### PR DESCRIPTION
- Evidence in datamining has shown `_Wrath` to be the new suffix, hence it's preliminary implementation.

CF Releases fallback to TBC's Game Type ID, to prevent accidental releases as Retail and since the API is closer based to 9.2.5 and TBC then anything else.