### PR TITLE
Bugfix: toc_root_paths not detecting in package-as if not moved?

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -881,6 +881,7 @@ if [ -f "$pkgmeta_file" ]; then
 						;;
 					package-as)
 						package=$yaml_value
+						toc_root_paths["$topdir/$yaml_value/"]="$yaml_value"
 						;;
 					wowi-create-changelog)
 						if [ "$yaml_value" = "no" ]; then


### PR DESCRIPTION
When using the `package-as` variable in pkgmeta, if the file isn't referenced in `move-folders`, it will never be picked up in the statements on line 1207-1213.