### PR TITLE
Update TOC interface parsing to allow for 6 digit interface versions

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1185,7 +1185,7 @@ set_build_version() {
 				# root addon interfaces take priority
 				if [[ -z $game_type || $game_type == "$toc_game_type" ]] && [[ -z ${game_type_interface[$toc_game_type]} || ${toc_root_paths[${path%/*}]} == "$package" ]]; then
 					game_type_interface[$toc_game_type]="$toc_version"
-					game_type_version[$toc_game_type]=$( printf "%d.%d.%d" "${toc_version:0:1}" "${toc_version:1:2}" "${toc_version:3:2}" )
+					game_type_version[$toc_game_type]=$( printf "%d.%d.%d" "${toc_version:0: -4}" "${toc_version: -4:2}" "${toc_version: -2:2}" )
 				fi
 			done
 		done


### PR DESCRIPTION
With Retail moving to 10.0, Interface versions are expected to change to
6 digits, with a 2 digit major version in the front. Adjust the parsing
  of the interface version to accomodate for this.