### PR TITLE
Use new github action output format

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2469,7 +2469,7 @@ if [ -z "$skip_zipfile" ]; then
 	fi
 
 	if [ -n "$GITHUB_ACTIONS" ]; then
-		echo "::set-output name=archive_path::${archive}"
+		echo "ARCHIVE_PATH=${archive}" >> $GITHUB_OUTPUT
 	fi
 
 	start_group "Creating archive: $archive_name ($archive_label)" "archive"


### PR DESCRIPTION
GitHub has deprecated the `set-output` meta-methods of actions/workflows for something better. The workflow throws a warning with the current implementation.

To read this output use `${{ steps.packager.outputs.archive_path }}` (same as before).

More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
New docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter