### PR TITLE
Use `GITHUB_REF_NAME` if available to disambiguate tags pointing to the same commit

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -537,7 +537,11 @@ set_info_git() {
 	si_previous_tag=
 	si_previous_revision=
 	_si_tag=$( git -C "$si_repo_dir" describe --tags --always --abbrev=7 2>/dev/null )
-	si_tag=$( git -C "$si_repo_dir" describe --tags --always --abbrev=0 2>/dev/null )
+	if [[ -n $GITHUB_REF_NAME ]]; then
+		si_tag=$( git -C "$si_repo_dir" describe --tags --always --abbrev=0 2>/dev/null )
+	else
+		si_tag=$GITHUB_REF_NAME
+	fi
 	# Set $si_project_version to the version number of HEAD. May be empty if there are no commits.
 	si_project_version="$si_tag"
 	# The HEAD is not tagged if the HEAD is several commits past the most recent tag.


### PR DESCRIPTION
This addresses https://github.com/BigWigsMods/packager/issues/156 when using github.  This does not address the case when there are annotated tags available and the packager is running outside github.